### PR TITLE
Fix Danmaku ass timestamp when it's greater than 1 hour

### DIFF
--- a/src/Core/danmaku2ass/Utils.cs
+++ b/src/Core/danmaku2ass/Utils.cs
@@ -62,6 +62,7 @@ namespace Core.danmaku2ass
             int second = (int)(i % 60.0f);
 
             int hour = (int)Math.Floor(min / 60.0);
+            min %= 60;
 
             return $"{hour:D}:{min:D2}:{second:D2}.{dec:D2}";
         }


### PR DESCRIPTION
When the timestamp in ass is greater than 1 hour, there's a bug that the minute part can exceed 59, which is caused by it's not mod by 60. https://github.com/leiurayer/downkyi/issues/126 has this bug reported too.

This 1-liner PR should fix it. But since the original project doesn't have build scripts, I'm not able to verify it locally.
