### PR TITLE
Fix FormatFileName

### DIFF
--- a/src/DownKyi.Core/Utils/Format.cs
+++ b/src/DownKyi.Core/Utils/Format.cs
@@ -199,7 +199,22 @@ namespace DownKyi.Core.Utils
             destName = Regex.Replace(destName, @"\p{C}+", string.Empty);
 
             // 移除前导和尾部的空白字符、dot符
-            return destName.Trim('.').Trim();
+            int i, j;
+            for (i = 0; i < destName.Length; i++)
+            {
+                if (destName[i] != ' ' && destName[i] != '.')
+                {
+                    break;
+                }
+            }
+            for (j = destName.Length - 1; j >= 0; j--)
+            {
+                if (destName[j] != ' ' && destName[j] != '.')
+                {
+                    break;
+                }
+            }
+            return destName.Substring(i, j - i + 1);
         }
 
     }


### PR DESCRIPTION
修复当文件名以连续的点、空格、点结尾 (例如"abc . . ")时，无法完全去除开头/结尾的点和空格 
需要额外处理当文件名都是非法字符的情况