### PR TITLE
确认下载路径之前检查盘符是否存在

### DIFF
--- a/src/DownKyi/Languages/Default.xaml
+++ b/src/DownKyi/Languages/Default.xaml
@@ -345,6 +345,7 @@
     <system:String x:Key="IsDefaultDownloadDirectoryTip">选中后下次将不会弹出此窗口</system:String>
     <system:String x:Key="Download">下载</system:String>
     <system:String x:Key="WarningNullDirectory">文件夹路径不能为空</system:String>
+    <system:String x:Key="DriveNotFound">该磁盘不存在</system:String>
 
     <!--  ViewParsingSelector  -->
     <system:String x:Key="ParsingSelector">选择解析项</system:String>

--- a/src/DownKyi/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi/Services/Download/AddToDownloadService.cs
@@ -191,6 +191,14 @@ namespace DownKyi.Services.Download
                 });
             }
 
+            if (!Directory.Exists(Directory.GetDirectoryRoot(directory)))
+            {
+                var alert = new AlertService(dialogService);
+                alert.ShowError(DictionaryResource.GetString("DriveNotFound"));
+
+                directory = string.Empty;
+            }
+
             // 下载设置dialog中如果点击取消或者关闭窗口，
             // 会返回空字符串，
             // 这时直接退出


### PR DESCRIPTION
## 问题描述

DownKyi不会检测盘符是否存在，若出现了不存在的磁盘，软件会直接崩溃。这在无法输入路径的情况下确实很难出现问题，但仍然有一些方式能够触发。因此添加了一段检测磁盘的代码。

## 复现方法

为下载路径指定一块不存在的磁盘，此后下载视频，程序会直接崩溃。

## 例子

向U盘中下载视频，此后拔掉U盘再下载。途中忘记修改下载路径。