### PR TITLE
升级二维码版本，修复登录无法生成二维码的问题。

### DIFF
--- a/src/DownKyi.Core/BiliApi/LoginNew/LoginQR.cs
+++ b/src/DownKyi.Core/BiliApi/LoginNew/LoginQR.cs
@@ -55,7 +55,7 @@ namespace DownKyi.Core.BiliApi.LoginNew
                 return null;
             }
         }
-        
+
         /// <summary>
         /// 获得登录二维码
         /// </summary>
@@ -83,7 +83,7 @@ namespace DownKyi.Core.BiliApi.LoginNew
         public static BitmapImage GetLoginQRCode(string url)
         {
             // 设置的参数影响app能否成功扫码
-            Bitmap qrCode = Utils.QRCode.EncodeQRCode(url, 12, 10, null, 0, 0, false);
+            Bitmap qrCode = Utils.QRCode.EncodeQRCode(url, 15, 10, null, 0, 0, false);
 
             MemoryStream ms = new MemoryStream();
             qrCode.Save(ms, System.Drawing.Imaging.ImageFormat.Bmp);


### PR DESCRIPTION
error log: 
```
2025/6/8 18:26:42   [34]   ERROR   PageLogin  The given payload exceeds the maximum size of the QR code standard. The maximum size allowed for the choosen paramters (ECC level=H, EncodingMode=Byte, FixedVersion=10) is 119 byte.
   at QRCoder.QRCodeGenerator.GenerateQrCode(String plainText, ECCLevel eccLevel, Boolean forceUtf8, Boolean utf8BOM, EciMode eciMode, Int32 requestedVersion)
   at DownKyi.Core.Utils.QRCode.EncodeQRCode(String msg, Int32 version, Int32 pixel, String icon_path, Int32 icon_size, Int32 icon_border, Boolean white_edge)
   at DownKyi.Core.BiliApi.LoginNew.LoginQR.GetLoginQRCode(String url)
   at DownKyi.ViewModels.ViewLoginViewModel.<>c__DisplayClass23_0.<Login>b__0()
   at System.Windows.Threading.DispatcherOperation.InvokeDelegateCore()
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Windows.Threading.DispatcherOperation.Wait(TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.InvokeImpl(DispatcherOperation operation, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke(Action callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke(Action callback)
   at DownKyi.ViewModels.BaseViewModel.PropertyChangeAsync(Action callback)
   at DownKyi.ViewModels.ViewLoginViewModel.Login()
----------------------------------------------------
```